### PR TITLE
add function to get all legal moves for a specific square

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "rschess"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "image 0.25.1",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rschess"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "A Rust chess library with the aim to be as feature-rich as possible"
 repository = "https://github.com/Python3-8/rschess"

--- a/src/board.rs
+++ b/src/board.rs
@@ -87,8 +87,8 @@ impl Board {
         }
     }
 
-    /// Generates the legal moves for a specific square in the position.
-    pub fn gen_legel_moves_sq(&self, sq: usize) -> Vec<Move> {
+    /// Generates the pseudolegal moves for a specific square in the position.
+    pub fn gen_pseudolegal_moves_sq(&self, sq: usize) -> Vec<Move> {
         if self.ongoing {
             self.position.gen_pseudolegal_moves_single_square(sq, &self.position.content[sq])
         } else {

--- a/src/board.rs
+++ b/src/board.rs
@@ -87,6 +87,15 @@ impl Board {
         }
     }
 
+    /// Generates the legal moves for a specific square in the position.
+    pub fn gen_legel_moves_sq(&self, sq: usize) -> Vec<Move> {
+        if self.ongoing {
+            self.position.gen_pseudolegal_moves_single_square(sq, &self.position.content[sq])
+        } else {
+            Vec::new()
+        }
+    }
+
     /// Checks whether a move is legal in the position.
     pub fn is_legal(&self, move_: Move) -> bool {
         helpers::as_legal(move_, &self.gen_legal_moves()).is_some()


### PR DESCRIPTION
I added a function to get the psuedolegal  moves of a specific square and then made the function that gets ALL of them use that.  This will be useful to someone like me who wants to make a chess game and wants to be able to easily see all legal moves for a specific piece