### PR TITLE
To_fen works if R stands between R and K

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -61,33 +61,25 @@ impl Position {
         let mut castling_availability = String::new();
         let count_rooks = |rng, color| helpers::count_piece(rng, Piece(PieceType::R, color), content);
         let (wk, bk) = (helpers::find_king(Color::White, content), helpers::find_king(Color::Black, content));
-        if castling_rights[0].is_some() {
+        if let Some(idx) = castling_rights[0] {
             castling_availability.push(if count_rooks(wk + 1..8, Color::White) == 1 {
                 'K'
             } else {
-                helpers::idx_to_sq(castling_rights[0].unwrap()).0.to_ascii_uppercase()
+                helpers::idx_to_sq(idx).0.to_ascii_uppercase()
             });
         }
-        if castling_rights[1].is_some() {
+        if let Some(idx) = castling_rights[1] {
             castling_availability.push(if count_rooks(0..wk, Color::White) == 1 {
                 'Q'
             } else {
-                helpers::idx_to_sq(castling_rights[1].unwrap()).0.to_ascii_uppercase()
+                helpers::idx_to_sq(idx).0.to_ascii_uppercase()
             });
         }
-        if castling_rights[2].is_some() {
-            castling_availability.push(if count_rooks(bk + 1..64, Color::Black) == 1 {
-                'k'
-            } else {
-                helpers::idx_to_sq(castling_rights[2].unwrap()).0
-            });
+        if let Some(idx) = castling_rights[2] {
+            castling_availability.push(if count_rooks(bk + 1..64, Color::Black) == 1 { 'k' } else { helpers::idx_to_sq(idx).0 });
         }
-        if castling_rights[3].is_some() {
-            castling_availability.push(if count_rooks(56..bk, Color::Black) == 1 {
-                'q'
-            } else {
-                helpers::idx_to_sq(castling_rights[2].unwrap()).0
-            });
+        if let Some(idx) = castling_rights[3] {
+            castling_availability.push(if count_rooks(56..bk, Color::Black) == 1 { 'q' } else { helpers::idx_to_sq(idx).0 });
         }
         if castling_availability.is_empty() {
             castling_availability.push('-');

--- a/src/test.rs
+++ b/src/test.rs
@@ -329,6 +329,25 @@ fn valid_make_move_san() {
     println!("\n{}", board.pretty_print(Color::White, true));
 }
 
+#[test]
+fn to_fen_castling_rights_on_rook_interruption() {
+    let mut bq_board = Board::from_fen(Fen::try_from("r3k3/8/1r6/8/8/8/8/7K b q - 0 2").unwrap());
+    bq_board.make_move_uci("b6b8").unwrap();
+    assert_eq!(bq_board.to_fen().to_string(), "rr2k3/8/8/8/8/8/8/7K w a - 1 2");
+
+    let mut bk_board = Board::from_fen(Fen::try_from("4k2r/8/6r1/8/8/8/8/K7 b k - 0 2").unwrap());
+    bk_board.make_move_uci("g6g8").unwrap();
+    assert_eq!(bk_board.to_fen().to_string(), "4k1rr/8/8/8/8/8/8/K7 w h - 1 2");
+
+    let mut wq_board = Board::from_fen(Fen::try_from("7k/1R6/8/8/8/8/8/R3K3 w Q - 0 2").unwrap());
+    wq_board.make_move_uci("b7b1").unwrap();
+    assert_eq!(wq_board.to_fen().to_string(), "7k/8/8/8/8/8/8/RR2K3 b A - 1 3");
+
+    let mut wk_board = Board::from_fen(Fen::try_from("k7/6R1/8/8/8/8/8/4K2R w K - 0 2").unwrap());
+    wk_board.make_move_uci("g7g1").unwrap();
+    assert_eq!(wk_board.to_fen().to_string(), "k7/8/8/8/8/8/8/4K1RR b H - 1 3");
+}
+
 #[cfg(feature = "pgn")]
 #[test]
 #[ignore]


### PR DESCRIPTION
Fixes #10

Previously after a move that placed a black rook between castlable black king and castleable black rook like `r..rk...` caused to_fen() to crash